### PR TITLE
docs(readme): fix doc links broken by #26 declutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,12 +334,12 @@ The long-term vision is a **Governance-as-Code platform**: a declarative policy 
 
 | Document | Purpose |
 |----------|---------|
-| [ARCHITECTURE.md](ARCHITECTURE.md) | Full technical architecture with component diagrams and data flow |
-| [ECOSYSTEM.md](ECOSYSTEM.md) | Ecosystem overview, integration patterns, deployment models |
-| [COMPREHENSIVE_CRITIQUE.md](COMPREHENSIVE_CRITIQUE.md) | Self-assessment: logic audit, rhetorical analysis, blindspots, evolution plan |
-| [ROADMAP.md](ROADMAP.md) | Strategic roadmap with success metrics and risk management |
-| [GOVERNANCE_ANALYSIS.md](GOVERNANCE_ANALYSIS.md) | Audit log of governance improvements and validation results |
-| [PRODUCT_ARCHITECTURE.md](PRODUCT_ARCHITECTURE.md) | Framework-as-Code product design and business model |
+| [ARCHITECTURE.md](./docs/ARCHITECTURE.md) | Full technical architecture with component diagrams and data flow |
+| [ECOSYSTEM.md](./docs/ECOSYSTEM.md) | Ecosystem overview, integration patterns, deployment models |
+| [COMPREHENSIVE_CRITIQUE.md](./docs/COMPREHENSIVE_CRITIQUE.md) | Self-assessment: logic audit, rhetorical analysis, blindspots, evolution plan |
+| [ROADMAP.md](./docs/ROADMAP.md) | Strategic roadmap with success metrics and risk management |
+| [GOVERNANCE_ANALYSIS.md](./docs/GOVERNANCE_ANALYSIS.md) | Audit log of governance improvements and validation results |
+| [PRODUCT_ARCHITECTURE.md](./docs/PRODUCT_ARCHITECTURE.md) | Framework-as-Code product design and business model |
 | [config/schema.json](config/schema.json) | JSON Schema for governance.yml validation |
 | [ORGAN-IV: agentic-titan](https://github.com/organvm-iv-taxis/agentic-titan) | Downstream orchestration engine consuming governance primitives |
 


### PR DESCRIPTION
## What

The `Declutter root per #26 §8` commit (`d42661a`) moved 6 docs into `docs/` but left the **Cross-References** table in `README.md` pointing at the old root paths — so those links 404 on GitHub `main` right now.

Repoints to `./docs/`:
- `ARCHITECTURE.md`, `ECOSYSTEM.md`, `COMPREHENSIVE_CRITIQUE.md`, `ROADMAP.md`, `GOVERNANCE_ANALYSIS.md`, `PRODUCT_ARCHITECTURE.md`

Links to files that stayed at root (`CONTRIBUTING.md`, `LICENSE`, `config/schema.json`, `.github/SECURITY.md`) are untouched — they already resolve.

## Why a PR (not direct-to-main)

Direct push to `main` is gated per branch-governance Rule #12; this routes the regression-fix through review like the other #26 follow-ups this cycle (classroom-rpg #131, stakeholder-portal #55).

## Impact

Markdown-only. No build/test impact. Deterministic output of `scripts/fix-readme-doc-links.py` in the governance corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)